### PR TITLE
Add a Word Counter CLI

### DIFF
--- a/word-counter/main.go
+++ b/word-counter/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+)
+
+func main() {
+	lineFlag := flag.Bool("l", false, "Count lines of given input")
+	byteFlag := flag.Bool("b", false, "Count bytes of given input")
+	flag.Parse()
+
+	fmt.Println(count(os.Stdin, *lineFlag, *byteFlag))
+}
+
+func count(reader io.Reader, lineFlag bool, byteFlag bool) int {
+	scanner := bufio.NewScanner(reader)
+
+	if byteFlag {
+		scanner.Split(bufio.ScanBytes)
+	} else if !lineFlag {
+		scanner.Split(bufio.ScanWords)
+	}
+
+	counter := 0
+
+	for scanner.Scan() {
+		counter++
+	}
+
+	if err := scanner.Err(); err != nil {
+		panic(err)
+	}
+
+	return counter
+}

--- a/word-counter/main_test.go
+++ b/word-counter/main_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestCountWords(t *testing.T) {
+	input := bytes.NewBufferString("word1 word2 word3 word4\n")
+	expectedOutput := 4
+
+	result := count(input, false, false)
+
+	if result != expectedOutput {
+		t.Errorf("Expected %d words, got %d instead.", expectedOutput, result)
+	}
+}
+
+func TestCountLines(t *testing.T) {
+	input := bytes.NewBufferString("line1\nline2 word1\nline3\nline4\nline5")
+	expectedOutput := 5
+
+	result := count(input, true, false)
+
+	if result != expectedOutput {
+		t.Errorf("Expected %d lines, got %d instead.", expectedOutput, result)
+	}
+}
+
+func TestCountBytes(t *testing.T) {
+	input := bytes.NewBufferString("pls count me as bytes")
+	expectedOutput := 21
+
+	result := count(input, false, true)
+
+	if result != expectedOutput {
+		t.Errorf("Expected %d bytes, got %d instead.", expectedOutput, result)
+	}
+}


### PR DESCRIPTION
This CLI basically returns the count of given `words`, `bytes` or `lines` of a string.

To customize the return type, custom flags are added:

`-l`: Indicates that the counter will count lines
`-b`: Indicates that the counter will count bytes

The default behavior is to count words of a given string.

Since the purpose of the project is not creating production ready CLI's but to experiment with flags and os.Stdin, the count() method is not written in an extendable way.