### PR TITLE
Add a TODO CLI

### DIFF
--- a/todo/cmd/todo/main.go
+++ b/todo/cmd/todo/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"github.com/acikgozb/cli-playground/todo"
+	"os"
+	"strings"
+)
+
+const todoFileName = "todo.json"
+
+func main() {
+	l := &todo.List{}
+
+	if err := l.Get(todoFileName); err != nil && !os.IsNotExist(err) {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	switch {
+	case len(os.Args) == 1:
+		for _, item := range *l {
+			fmt.Println(item.Task)
+		}
+	default:
+		item := strings.Join(os.Args[1:], " ")
+		l.Add(item)
+
+		if err := l.Save(todoFileName); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+}

--- a/todo/cmd/todo/main.go
+++ b/todo/cmd/todo/main.go
@@ -1,15 +1,21 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"github.com/acikgozb/cli-playground/todo"
 	"os"
-	"strings"
 )
 
 const todoFileName = "todo.json"
 
 func main() {
+	taskFlag := flag.String("task", "", "Adds given task to the todo list")
+	listFlag := flag.Bool("list", false, "Lists all todo items that are not completed")
+	completeFlag := flag.Int("complete", 0, "Marks given itemNumber as completed")
+
+	flag.Parse()
+
 	l := &todo.List{}
 
 	if err := l.Get(todoFileName); err != nil && !os.IsNotExist(err) {
@@ -18,17 +24,30 @@ func main() {
 	}
 
 	switch {
-	case len(os.Args) == 1:
+	case *listFlag:
 		for _, item := range *l {
-			fmt.Println(item.Task)
+			if !item.Done {
+				fmt.Println(item.Task)
+			}
 		}
-	default:
-		item := strings.Join(os.Args[1:], " ")
-		l.Add(item)
+	case *completeFlag > 0:
+		if err := l.Complete(*completeFlag); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 
 		if err := l.Save(todoFileName); err != nil {
 			_, _ = fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
+	case *taskFlag != "":
+		l.Add(*taskFlag)
+		if err := l.Save(todoFileName); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	default:
+		_, _ = fmt.Fprintln(os.Stderr, "An invalid operation is passed.")
+		os.Exit(1)
 	}
 }

--- a/todo/cmd/todo/main.go
+++ b/todo/cmd/todo/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 )
 
-const todoFileName = "todo.json"
+var todoFileName = "todo.json"
 
 func main() {
 	taskFlag := flag.String("task", "", "Adds given task to the todo list")
@@ -23,6 +23,10 @@ func main() {
 	}
 
 	flag.Parse()
+
+	if os.Getenv("TODO_FILENAME") != "" {
+		todoFileName = os.Getenv("TODO_FILENAME")
+	}
 
 	l := &todo.List{}
 

--- a/todo/cmd/todo/main.go
+++ b/todo/cmd/todo/main.go
@@ -14,6 +14,14 @@ func main() {
 	listFlag := flag.Bool("list", false, "Lists all todo items that are not completed")
 	completeFlag := flag.Int("complete", 0, "Marks given itemNumber as completed")
 
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Todo tool. Developed by acikgozb.\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "The CLI is NOT production ready, keep this in mind while using.\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "Copyright 2023\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage information:\n")
+		flag.PrintDefaults()
+	}
+
 	flag.Parse()
 
 	l := &todo.List{}

--- a/todo/cmd/todo/main.go
+++ b/todo/cmd/todo/main.go
@@ -33,11 +33,7 @@ func main() {
 
 	switch {
 	case *listFlag:
-		for _, item := range *l {
-			if !item.Done {
-				fmt.Println(item.Task)
-			}
-		}
+		fmt.Print(l)
 	case *completeFlag > 0:
 		if err := l.Complete(*completeFlag); err != nil {
 			_, _ = fmt.Fprintln(os.Stderr, err)

--- a/todo/cmd/todo/main_test.go
+++ b/todo/cmd/todo/main_test.go
@@ -58,7 +58,7 @@ func TestTodoCLI(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		expected := task + "\n"
+		expected := fmt.Sprintf("   1: %s\n", task)
 		if expected != string(out) {
 			t.Errorf("Expected %s from cli but got %s", expected, string(out))
 		}

--- a/todo/cmd/todo/main_test.go
+++ b/todo/cmd/todo/main_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -45,7 +44,7 @@ func TestTodoCLI(t *testing.T) {
 	cmdPath := filepath.Join(dir, binName)
 
 	t.Run("AddNewTask", func(t *testing.T) {
-		cmd := exec.Command(cmdPath, strings.Split(task, " ")...)
+		cmd := exec.Command(cmdPath, "-task", task)
 
 		if err := cmd.Run(); err != nil {
 			t.Fatal(err)
@@ -53,7 +52,7 @@ func TestTodoCLI(t *testing.T) {
 	})
 
 	t.Run("ListExistingTasks", func(t *testing.T) {
-		cmd := exec.Command(cmdPath)
+		cmd := exec.Command(cmdPath, "-list")
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			t.Fatal(err)

--- a/todo/cmd/todo/main_test.go
+++ b/todo/cmd/todo/main_test.go
@@ -1,0 +1,67 @@
+package main_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var (
+	binName  = "todo"
+	fileName = "todo.json"
+)
+
+func TestMain(m *testing.M) {
+	fmt.Println("Building the tool...")
+
+	build := exec.Command("go", "build", "-o", binName)
+
+	if err := build.Run(); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "cannot build the binary %s: %s", binName, err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Running tests...")
+	result := m.Run()
+
+	fmt.Println("Cleaning up...")
+	os.Remove(binName)
+	os.Remove(fileName)
+
+	os.Exit(result)
+}
+
+func TestTodoCLI(t *testing.T) {
+	task := "test task number 1"
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmdPath := filepath.Join(dir, binName)
+
+	t.Run("AddNewTask", func(t *testing.T) {
+		cmd := exec.Command(cmdPath, strings.Split(task, " ")...)
+
+		if err := cmd.Run(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("ListExistingTasks", func(t *testing.T) {
+		cmd := exec.Command(cmdPath)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := task + "\n"
+		if expected != string(out) {
+			t.Errorf("Expected %s from cli but got %s", expected, string(out))
+		}
+	})
+}

--- a/todo/cmd/todo/main_test.go
+++ b/todo/cmd/todo/main_test.go
@@ -2,6 +2,7 @@ package main_test
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -34,7 +35,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestTodoCLI(t *testing.T) {
-	task := "test task number 1"
+	task1 := "test task number 1"
+	task2 := "Hello from pipe"
 
 	dir, err := os.Getwd()
 	if err != nil {
@@ -44,10 +46,31 @@ func TestTodoCLI(t *testing.T) {
 	cmdPath := filepath.Join(dir, binName)
 
 	t.Run("AddNewTask", func(t *testing.T) {
-		cmd := exec.Command(cmdPath, "-task", task)
+		cmd := exec.Command(cmdPath, "-add", task1)
 
 		if err := cmd.Run(); err != nil {
 			t.Fatal(err)
+		}
+	})
+
+	t.Run("AddNewTaskFromSTDIN", func(t *testing.T) {
+		cmd := exec.Command(cmdPath, "-add")
+		cmdStdIn, err := cmd.StdinPipe()
+		if err != nil {
+			t.Errorf("Error occured when creating a stdin pipe: %s", err.Error())
+		}
+
+		_, err = io.WriteString(cmdStdIn, task2)
+		if err != nil {
+			t.Errorf("Error occured while writing to a pipe: %s", err.Error())
+		}
+
+		if err = cmdStdIn.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err = cmd.Run(); err != nil {
+			t.Errorf("Error occured while executing the -add command: %s", err.Error())
 		}
 	})
 
@@ -58,7 +81,7 @@ func TestTodoCLI(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		expected := fmt.Sprintf("   1: %s\n", task)
+		expected := fmt.Sprintf("   1: %s\n   2: %s\n", task1, task2)
 		if expected != string(out) {
 			t.Errorf("Expected %s from cli but got %s", expected, string(out))
 		}

--- a/todo/todo.go
+++ b/todo/todo.go
@@ -40,7 +40,6 @@ func (l *List) Complete(itemNumber int) error {
 	return nil
 }
 
-// slice ptr => original slice => underlying array
 func (l *List) Delete(itemNumber int) error {
 	if itemNumber > len(*l) || itemNumber <= 0 {
 		return fmt.Errorf("item %d does not exist", itemNumber)
@@ -73,4 +72,19 @@ func (l *List) Get(fileName string) error {
 	}
 
 	return json.Unmarshal(listJSON, l)
+}
+
+func (l *List) String() string {
+	formatted := ""
+
+	for index, item := range *l {
+		prefix := "   "
+		if item.Done {
+			prefix = "X  "
+		}
+
+		formatted += fmt.Sprintf("%s%d: %s\n", prefix, index+1, item.Task)
+	}
+
+	return formatted
 }

--- a/todo/todo.go
+++ b/todo/todo.go
@@ -1,0 +1,76 @@
+package todo
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+)
+
+type item struct {
+	Task        string
+	Done        bool
+	CreatedAt   time.Time
+	CompletedAt time.Time
+}
+
+type List []item
+
+func (l *List) Add(task string) {
+	todo := item{
+		Task:        task,
+		Done:        false,
+		CreatedAt:   time.Now(),
+		CompletedAt: time.Time{},
+	}
+
+	*l = append(*l, todo)
+}
+
+func (l *List) Complete(itemNumber int) error {
+	if itemNumber > len(*l) || itemNumber <= 0 {
+		return fmt.Errorf("item %d does not exist", itemNumber)
+	}
+
+	list := *l
+
+	list[itemNumber-1].Done = true
+	list[itemNumber-1].CompletedAt = time.Now()
+
+	return nil
+}
+
+// slice ptr => original slice => underlying array
+func (l *List) Delete(itemNumber int) error {
+	if itemNumber > len(*l) || itemNumber <= 0 {
+		return fmt.Errorf("item %d does not exist", itemNumber)
+	}
+
+	list := *l
+	list = append(list[:itemNumber-1], list[itemNumber:]...)
+	*l = list
+
+	return nil
+}
+
+func (l *List) Save(fileName string) error {
+	listJSON, err := json.Marshal(l)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(fileName, listJSON, 0644)
+}
+
+func (l *List) Get(fileName string) error {
+	listJSON, err := os.ReadFile(fileName)
+	if err != nil {
+		return err
+	}
+
+	if len(listJSON) == 0 {
+		return nil
+	}
+
+	return json.Unmarshal(listJSON, l)
+}

--- a/todo/todo_test.go
+++ b/todo/todo_test.go
@@ -1,0 +1,92 @@
+package todo_test
+
+import (
+	"github.com/acikgozb/cli-playground/todo"
+	"os"
+	"testing"
+)
+
+func TestList_Add(t *testing.T) {
+	l := todo.List{}
+
+	taskName := "New Task"
+	l.Add(taskName)
+
+	if l[0].Task != taskName {
+		t.Errorf("expected %s task name but got %s", taskName, l[0].Task)
+	}
+}
+
+func TestList_Complete(t *testing.T) {
+	l := todo.List{}
+
+	taskName := "New Task"
+	l.Add(taskName)
+
+	if l[0].Done {
+		t.Errorf("expected new task to not be completed")
+	}
+
+	err := l.Complete(1)
+	if err != nil {
+		t.Errorf("expected l.Complete to work but got err: %v", err)
+	}
+
+	if !l[0].Done {
+		t.Errorf("expected task to be completed but got %v", l[0].Done)
+	}
+}
+
+func TestList_Delete(t *testing.T) {
+	l := todo.List{}
+
+	tasks := []string{
+		"New Task1",
+		"New Task2",
+		"New Task3",
+	}
+
+	for _, task := range tasks {
+		l.Add(task)
+	}
+
+	err := l.Delete(2)
+	if err != nil {
+		t.Errorf("expected task to be removed but got err: %v", err)
+	}
+
+	if len(l) != 2 {
+		t.Errorf("expected list length to be 2 but got %d", len(l))
+	}
+
+	if l[1].Task != tasks[2] {
+		t.Errorf("expected %q after deleting the item, but got %q instead", tasks[2], l[1].Task)
+	}
+}
+
+func TestList_Save_Get(t *testing.T) {
+	list1 := todo.List{}
+	list2 := todo.List{}
+
+	taskName := "New Task"
+	list1.Add(taskName)
+
+	file, err := os.CreateTemp("", "test-list")
+	if err != nil {
+		t.Fatalf("unable to create file: %v", err)
+	}
+
+	defer os.Remove(file.Name())
+
+	if err = list1.Save(file.Name()); err != nil {
+		t.Errorf("unable to save the list to the file: %v", err)
+	}
+
+	if err = list2.Get(file.Name()); err != nil {
+		t.Errorf("unable to get the list from the file: %v", err)
+	}
+
+	if list1[0].Task != list2[0].Task {
+		t.Errorf("expected %q but got %q instead", list1[0].Task, list2[0].Task)
+	}
+}


### PR DESCRIPTION
A new CLI tool called `todo` is added to the monorepo.

It allows users:

- To add their TODO items either to the default file called `todo.json`, or a custom specified file.
- To add their TODO items either by directly using the CLI or by piping to it. eg: `echo "Todo1" | todo -add`
- To mark their TODO items as completed.
- To list their current TODO items.

CLI flags are tested in `main_test.go` to simulate an integration test.
The actual implementation of a todo list is added under `todo` package along with its unit tests.

This is the MVP of the tool and more flags will be implemented later on.