### PR TITLE
Implement TODO CLI Challenges

### DIFF
--- a/todo/cmd/todo/main.go
+++ b/todo/cmd/todo/main.go
@@ -27,6 +27,8 @@ func main() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Copyright 2023\n")
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage information:\n")
 		flag.PrintDefaults()
+		fmt.Fprintf(flag.CommandLine.Output(), "To add a new task, simply enter your task with the -add option:\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "todo -add \"My new task\"\n")
 	}
 
 	flag.Parse()

--- a/todo/cmd/todo/main.go
+++ b/todo/cmd/todo/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"github.com/acikgozb/cli-playground/todo"
@@ -17,6 +18,7 @@ func main() {
 	listFlag := flag.Bool("list", false, "Lists all todo items that are not completed")
 	completeFlag := flag.Int("complete", 0, "Marks the item with given itemNumber as completed")
 	deleteFlag := flag.Int("delete", 0, "Deletes the item with given itemNumber from the todo list")
+	verboseFlag := flag.Bool("verbose", false, "Enables verbose output, shows the item in JSON format")
 
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Todo tool. Developed by acikgozb.\n")
@@ -42,6 +44,14 @@ func main() {
 	switch {
 	case *listFlag:
 		fmt.Print(l)
+	case *verboseFlag:
+		jsonOut, err := getVerboseOut(l)
+		if err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+
+		fmt.Println(jsonOut)
 	case *completeFlag > 0:
 		if err := l.Complete(*completeFlag); err != nil {
 			_, _ = fmt.Fprintln(os.Stderr, err)
@@ -97,4 +107,13 @@ func getTask(r io.Reader, args ...string) (string, error) {
 	}
 
 	return s.Text(), nil
+}
+
+func getVerboseOut(list *todo.List) (string, error) {
+	byteOut, err := json.Marshal(list)
+	if err != nil {
+		return "", err
+	}
+
+	return string(byteOut), nil
 }

--- a/todo/cmd/todo/main.go
+++ b/todo/cmd/todo/main.go
@@ -15,7 +15,8 @@ var todoFileName = "todo.json"
 func main() {
 	addFlag := flag.Bool("add", false, "Adds given task to the todo list")
 	listFlag := flag.Bool("list", false, "Lists all todo items that are not completed")
-	completeFlag := flag.Int("complete", 0, "Marks given itemNumber as completed")
+	completeFlag := flag.Int("complete", 0, "Marks the item with given itemNumber as completed")
+	deleteFlag := flag.Int("delete", 0, "Deletes the item with given itemNumber from the todo list")
 
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Todo tool. Developed by acikgozb.\n")
@@ -59,6 +60,16 @@ func main() {
 		}
 
 		l.Add(task)
+
+		if err := l.Save(todoFileName); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	case *deleteFlag > 0:
+		if err := l.Delete(*deleteFlag); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 
 		if err := l.Save(todoFileName); err != nil {
 			_, _ = fmt.Fprintln(os.Stderr, err)

--- a/todo/cmd/todo/main.go
+++ b/todo/cmd/todo/main.go
@@ -19,6 +19,7 @@ func main() {
 	completeFlag := flag.Int("complete", 0, "Marks the item with given itemNumber as completed")
 	deleteFlag := flag.Int("delete", 0, "Deletes the item with given itemNumber from the todo list")
 	verboseFlag := flag.Bool("verbose", false, "Enables verbose output, shows the item in JSON format")
+	showNonCompletedFlag := flag.Bool("nc", false, "Shows tasks which are not completed")
 
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Todo tool. Developed by acikgozb.\n")
@@ -45,13 +46,16 @@ func main() {
 	case *listFlag:
 		fmt.Print(l)
 	case *verboseFlag:
-		jsonOut, err := getVerboseOut(l)
+		jsonOut, err := verboseOut(l)
 		if err != nil {
 			_, _ = fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 
 		fmt.Println(jsonOut)
+	case *showNonCompletedFlag:
+		ncTasks := l.NotCompletedTasks()
+		fmt.Print(ncTasks)
 	case *completeFlag > 0:
 		if err := l.Complete(*completeFlag); err != nil {
 			_, _ = fmt.Fprintln(os.Stderr, err)
@@ -109,7 +113,7 @@ func getTask(r io.Reader, args ...string) (string, error) {
 	return s.Text(), nil
 }
 
-func getVerboseOut(list *todo.List) (string, error) {
+func verboseOut(list *todo.List) (string, error) {
 	byteOut, err := json.Marshal(list)
 	if err != nil {
 		return "", err

--- a/todo/cmd/todo/main_test.go
+++ b/todo/cmd/todo/main_test.go
@@ -62,8 +62,6 @@ func TestTodoCLI(t *testing.T) {
 	})
 
 	t.Run("CompleteTask", func(t *testing.T) {
-		// exec complete command for task 1,
-		// list tasks, see that X exists in output.
 		cmd := exec.Command(cmdPath, "-complete", "1")
 		if err := cmd.Run(); err != nil {
 			t.Fatal(err)

--- a/todo/cmd/todo/main_test.go
+++ b/todo/cmd/todo/main_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 var (
-	binName  = "todo"
-	fileName = "todo.json"
+	binName         = "todo"
+	defaultFileName = "todo.json"
 )
 
 func TestMain(m *testing.M) {
@@ -30,6 +30,12 @@ func TestMain(m *testing.M) {
 
 	fmt.Println("Cleaning up...")
 	os.Remove(binName)
+
+	var fileName string
+	if os.Getenv("TODO_FILENAME") == "" {
+		fileName = defaultFileName
+	}
+
 	os.Remove(fileName)
 
 	os.Exit(result)

--- a/todo/cmd/todo/main_test.go
+++ b/todo/cmd/todo/main_test.go
@@ -86,4 +86,22 @@ func TestTodoCLI(t *testing.T) {
 			t.Errorf("Expected %s from cli but got %s", expected, string(out))
 		}
 	})
+
+	t.Run("DeleteTask", func(t *testing.T) {
+		deleteCmd := exec.Command(cmdPath, "-delete", "1")
+		if err := deleteCmd.Run(); err != nil {
+			t.Fatal(err)
+		}
+
+		listCmd := exec.Command(cmdPath, "-list")
+		out, err := listCmd.CombinedOutput()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := fmt.Sprintf("   1: %s\n", task2)
+		if expected != string(out) {
+			t.Errorf("Expected %s from cli but got %s", expected, string(out))
+		}
+	})
 }

--- a/todo/cmd/todo/main_test.go
+++ b/todo/cmd/todo/main_test.go
@@ -61,6 +61,26 @@ func TestTodoCLI(t *testing.T) {
 		}
 	})
 
+	t.Run("CompleteTask", func(t *testing.T) {
+		// exec complete command for task 1,
+		// list tasks, see that X exists in output.
+		cmd := exec.Command(cmdPath, "-complete", "1")
+		if err := cmd.Run(); err != nil {
+			t.Fatal(err)
+		}
+
+		listCmd := exec.Command(cmdPath, "-list")
+		out, err := listCmd.CombinedOutput()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		completedMark := "X"
+		if !strings.Contains(string(out), completedMark) {
+			t.Errorf("Expected %s mark on task but got: %s", completedMark, string(out))
+		}
+	})
+
 	t.Run("AddNewTaskFromSTDIN", func(t *testing.T) {
 		cmd := exec.Command(cmdPath, "-add")
 		cmdStdIn, err := cmd.StdinPipe()
@@ -89,7 +109,7 @@ func TestTodoCLI(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		expected := fmt.Sprintf("   1: %s\n   2: %s\n", task1, task2)
+		expected := fmt.Sprintf("X  1: %s\n   2: %s\n", task1, task2)
 		if expected != string(out) {
 			t.Errorf("Expected %s from cli but got %s", expected, string(out))
 		}

--- a/todo/cmd/todo/main_test.go
+++ b/todo/cmd/todo/main_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -102,6 +103,25 @@ func TestTodoCLI(t *testing.T) {
 		expected := fmt.Sprintf("   1: %s\n", task2)
 		if expected != string(out) {
 			t.Errorf("Expected %s from cli but got %s", expected, string(out))
+		}
+	})
+
+	t.Run("ShowListAsVerbose", func(t *testing.T) {
+		cmd := exec.Command(cmdPath, "-verbose")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		tokenStartIndex := strings.Index(string(out), "[{")
+		tokenEndIndex := strings.Index(string(out), "}]")
+
+		if tokenStartIndex != 0 {
+			t.Errorf("Expected %d as starting index, but got %d", 0, tokenStartIndex)
+		}
+
+		if tokenEndIndex == len(string(out))-1 {
+			t.Errorf("Expected }] at the end to contain in the output, but got %s", string(out))
 		}
 	})
 }

--- a/todo/cmd/todo/main_test.go
+++ b/todo/cmd/todo/main_test.go
@@ -36,8 +36,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestTodoCLI(t *testing.T) {
-	task1 := "test task number 1"
-	task2 := "Hello from pipe"
+	task1 := "mockAddNewTask item"
+	task2 := "mockAddNewTaskFromSTDIN item"
+	task3 := "mockShowNonCompletedTasks item"
 
 	dir, err := os.Getwd()
 	if err != nil {
@@ -122,6 +123,29 @@ func TestTodoCLI(t *testing.T) {
 
 		if tokenEndIndex == len(string(out))-1 {
 			t.Errorf("Expected }] at the end to contain in the output, but got %s", string(out))
+		}
+	})
+
+	t.Run("ShowNonCompletedTasks", func(t *testing.T) {
+		addCmd := exec.Command(cmdPath, "-add", task3)
+		if err := addCmd.Run(); err != nil {
+			t.Fatal(err)
+		}
+
+		completeCmd := exec.Command(cmdPath, "-complete", "2")
+		if err := completeCmd.Run(); err != nil {
+			t.Fatal(err)
+		}
+
+		ncCmd := exec.Command(cmdPath, "-nc")
+		out, err := ncCmd.CombinedOutput()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := fmt.Sprintf("   1: %s\n", task2)
+		if expected != string(out) {
+			t.Errorf("Expected to only see the not completed task, but got %s", string(out))
 		}
 	})
 }

--- a/todo/todo.go
+++ b/todo/todo.go
@@ -88,3 +88,15 @@ func (l *List) String() string {
 
 	return formatted
 }
+
+func (l *List) NotCompletedTasks() *List {
+	ncList := make(List, 0)
+
+	for _, item := range *l {
+		if !item.Done {
+			ncList = append(ncList, item)
+		}
+	}
+
+	return &ncList
+}

--- a/todo/todo.go
+++ b/todo/todo.go
@@ -16,15 +16,17 @@ type item struct {
 
 type List []item
 
-func (l *List) Add(task string) {
+func (l *List) Add(tasks []string) {
 	todo := item{
-		Task:        task,
 		Done:        false,
 		CreatedAt:   time.Now(),
 		CompletedAt: time.Time{},
 	}
 
-	*l = append(*l, todo)
+	for _, task := range tasks {
+		todo.Task = task
+		*l = append(*l, todo)
+	}
 }
 
 func (l *List) Complete(itemNumber int) error {


### PR DESCRIPTION
The following challenges are implemented to complete the TODO CLI chapter:

• Implement the flag `-del` to delete an item from the list. Use the `Delete()` method from the API to perform the action.
• Add another flag to enable `verbose` output, showing information like date/time.
• Add another flag to prevent displaying completed items.
• Update the custom usage function to include additional instructions on how to provide new tasks to the tool.
• Include test cases for the remaining options, such as `-complete`.
• Update the tests to use the `TODO_FILENAME` environment variable instead of hard-coding the test file name so that it doesn’t cause conflicts with an existing file.
• Update the `getTask()` function allowing it to handle multiline input from `STDIN`. Each line should be a new task in the list.


PS: The only thing that is focused during these implementations is the actual logic, not the code design. I'd have to say that it is for sure possible to create a more robust and readable design by:

- Organizing integration tests in a better way
- Write integration tests in a more independant way
- Abstracting most of the logic written in `main.go` file to separate packages
- ...
- .. 

This will be emphasized in README but the main goal is to get used to doing things with Go. That is why most of the code is kept as simple and as intact as possible.