### PR TITLE
Add Temp Markdown Files

### DIFF
--- a/markdown-previewer/main.go
+++ b/markdown-previewer/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -34,22 +35,33 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := run(*filename); err != nil {
+	if err := run(*filename, os.Stdout); err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }
 
-func run(filename string) error {
+func run(fileName string, out io.Writer) error {
 	// Read all the data from the input file and check for errors
-	input, err := os.ReadFile(filename)
+	input, err := os.ReadFile(fileName)
 	if err != nil {
 		return err
 	}
 
 	htmlData := parseContent(input)
 
-	outputName := fmt.Sprintf("%s.html", filepath.Base(filename))
-	fmt.Println(outputName)
+	// Create temporary file and check for errors
+	temp, tempErr := os.CreateTemp("", "mdp*.html")
+	if tempErr != nil {
+		return tempErr
+	}
+
+	if tempCloseErr := temp.Close(); tempCloseErr != nil {
+		return tempCloseErr
+	}
+
+	outputName := temp.Name()
+	fmt.Fprintln(out, outputName)
 
 	return saveHTML(outputName, htmlData)
 }
@@ -73,3 +85,4 @@ func parseContent(input []byte) []byte {
 
 	return outputHTML.Bytes()
 }
+	resultFile = "test1.md.html"

--- a/markdown-previewer/main_test.go
+++ b/markdown-previewer/main_test.go
@@ -3,12 +3,12 @@ package main
 import (
 	"bytes"
 	"os"
+	"strings"
 	"testing"
 )
 
 const (
 	inputFile  = "./testdata/test1.md"
-	resultFile = "test1.md.html"
 	goldenFile = "./testdata/test1.md.html"
 )
 
@@ -33,9 +33,13 @@ func TestParseContent(t *testing.T) {
 }
 
 func TestRun(t *testing.T) {
-	if err := run(inputFile); err != nil {
+	var mockStdOut bytes.Buffer
+
+	if err := run(inputFile, &mockStdOut); err != nil {
 		t.Fatal(err)
 	}
+
+	resultFile := strings.TrimSpace(mockStdOut.String())
 
 	result, err := os.ReadFile(resultFile)
 	if err != nil {


### PR DESCRIPTION
Instead of creating hardcoded `html` files, a temp file with the extension `mdp*.html` is generated for each convertion.