### PR TITLE
Add Template Support for Output HTML

### DIFF
--- a/markdown-previewer/main_test.go
+++ b/markdown-previewer/main_test.go
@@ -18,7 +18,10 @@ func TestParseContent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result := parseContent(input)
+	result, err := parseContent(input, "")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	expected, err := os.ReadFile(goldenFile)
 	if err != nil {
@@ -34,9 +37,10 @@ func TestParseContent(t *testing.T) {
 
 func TestRun(t *testing.T) {
 	skipPreview := true
+	templateFileName := ""
 	var mockStdOut bytes.Buffer
 
-	if err := run(inputFile, &mockStdOut, skipPreview); err != nil {
+	if err := run(inputFile, templateFileName, &mockStdOut, skipPreview); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
`templates/html` package is used to allow users to insert a dynamic HTML inside the body of the output.