### PR TITLE
Allow users to archive a directory

### DIFF
--- a/walk/main.go
+++ b/walk/main.go
@@ -15,11 +15,12 @@ var (
 )
 
 type config struct {
-	ext  string
-	size int64
-	list bool
-	del  bool
-	wLog io.Writer
+	ext     string
+	size    int64
+	list    bool
+	del     bool
+	wLog    io.Writer
+	archive string
 }
 
 func main() {
@@ -29,6 +30,7 @@ func main() {
 	ext := flag.String("ext", "", "File extension to filter out")
 	size := flag.Int64("size", 0, "Minimum file size")
 	del := flag.Bool("del", false, "Delete files")
+	archive := flag.String("archive", "", "Archive directory")
 
 	flag.Parse()
 
@@ -42,11 +44,12 @@ func main() {
 	}
 
 	c := config{
-		ext:  *ext,
-		size: *size,
-		list: *list,
-		del:  *del,
-		wLog: f,
+		ext:     *ext,
+		size:    *size,
+		list:    *list,
+		del:     *del,
+		wLog:    f,
+		archive: *archive,
 	}
 
 	if err := run(*root, os.Stdout, c); err != nil {
@@ -71,6 +74,12 @@ func run(root string, out io.Writer, cfg config) error {
 			// If list was explicitly set, don't do anything else
 			if cfg.list {
 				return listFile(path, out)
+			}
+
+			if cfg.archive != "" {
+				if err := archiveFile(cfg.archive, root, path); err != nil {
+					return err
+				}
 			}
 
 			// If delete flag is given, delete the file


### PR DESCRIPTION
A new flag called archive is added to walk CLI to allow users to archive a directory.

This operation can be mixed with deletion, so they can archive first and then delete the original files.

Tests are added for archiving as well.