### PR TITLE
Init goci tool

### DIFF
--- a/goci/errors.go
+++ b/goci/errors.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrValidation = errors.New("validation failed")
+
+// Define a custom error to centralize the errors in each step of the CI pipeline
+type StepErr struct {
+	step  string
+	msg   string
+	cause error
+}
+
+// This method is added to the struct to satisfy the Error interface
+func (s *StepErr) Error() string {
+	return fmt.Sprintf("Step: %q: %s: Cause: %v", s.step, s.msg, s.cause)
+}
+
+// This method is added to see whether the target error matches a StepErr
+func (s *StepErr) Is(target error) bool {
+	t, ok := target.(*StepErr)
+	if !ok {
+		return false
+	}
+
+	return t.step == s.step
+}
+
+// errors.Is might try to Unwrap the underlying error, therefore implement Unwrap as well
+func (s *StepErr) Unwrap() error {
+	return s.cause
+}

--- a/goci/main.go
+++ b/goci/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+)
+
+func main() {
+	proj := flag.String("p", "", "Project directory")
+	flag.Parse()
+
+	if err := run(*proj, os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(proj string, out io.Writer) error {
+	if proj == "" {
+		return fmt.Errorf("project directory is required: %w", ErrValidation)
+	}
+
+	// The first step of the pipeline is to build the project using go build.
+	// The errors package is used to prevent go build from creating an executable file.
+	// Go build does not create an executable if it is used for building multiple packages.
+	args := []string{"build", ".", "errors"}
+
+	buildCmd := exec.Command("go", args...)
+	buildCmd.Dir = proj
+
+	if err := buildCmd.Run(); err != nil {
+		return &StepErr{step: "go build", msg: "go build failed", cause: err}
+	}
+
+	_, err := fmt.Fprintln(out, "Go build: SUCCESS")
+	return err
+}


### PR DESCRIPTION
A new tool is added to the monorepo which simulates a concurrent CI pipeline. The initial entry point is added along with a error struct which will help us centralize the error handling.

The tests will be added later on.