### PR TITLE
Add unit tests for initial goci tool

### DIFF
--- a/goci/main_test.go
+++ b/goci/main_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestRun(t *testing.T) {
+	testCases := []struct {
+		name   string
+		proj   string
+		out    string
+		expErr error
+	}{
+		{
+			name:   "success",
+			proj:   "./testdata/tool/",
+			out:    "Go build: SUCCESS\n",
+			expErr: nil,
+		},
+		{
+			name:   "fail",
+			proj:   "./testdata/toolErr/",
+			out:    "",
+			expErr: &StepErr{step: "go build"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			err := run(tc.proj, &out)
+
+			if tc.expErr != nil {
+				if err == nil {
+					t.Errorf("Excepted error: %q. Got nil instead", tc.expErr)
+					return
+				}
+
+				if !errors.Is(err, tc.expErr) {
+					t.Errorf("Excepted error: %q. Got %q", tc.expErr, err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %q", err)
+			}
+
+			if out.String() != tc.out {
+				t.Errorf("Excepted output: %q. Got %q instead", tc.out, out.String())
+			}
+		})
+	}
+}

--- a/goci/testdata/tool/add.go
+++ b/goci/testdata/tool/add.go
@@ -1,0 +1,5 @@
+package add
+
+func add(a, b int) int {
+	return a + b
+}

--- a/goci/testdata/toolErr/add.go
+++ b/goci/testdata/toolErr/add.go
@@ -1,0 +1,5 @@
+package add
+
+func add(a, b int) int {
+	return c + b
+}


### PR DESCRIPTION
Two test projects are added to simulate a success and a fail scenario.

The unit tests for go build step is added under main_test.go.