### PR TITLE
Centralize goci pipeline steps

### DIFF
--- a/goci/exceptionStep.go
+++ b/goci/exceptionStep.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+)
+
+type exceptionStep struct {
+	step
+}
+
+// Since there are no new fields for this type, we can call newStep directly.
+func newExceptionStep(name, exe, message, proj string, args []string) exceptionStep {
+	s := exceptionStep{}
+	s.step = newStep(name, exe, message, proj, args)
+	return s
+}
+
+// Define a new version of execute() method that is different than what step{} has.
+func (s exceptionStep) execute() (string, error) {
+	cmd := exec.Command(s.exe, s.args...)
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+
+	cmd.Dir = s.proj
+
+	if err := cmd.Run(); err != nil {
+		return "", &StepErr{
+			step:  s.name,
+			msg:   "failed to execute",
+			cause: err,
+		}
+	}
+
+	// If there is no error but output is not empty,
+	// It means the error is captured on output.
+	if out.Len() > 0 {
+		return "", &StepErr{
+			step:  s.name,
+			msg:   fmt.Sprintf("invalid format: %s", out.String()),
+			cause: nil,
+		}
+	}
+
+	return s.message, nil
+}

--- a/goci/main.go
+++ b/goci/main.go
@@ -7,6 +7,10 @@ import (
 	"os"
 )
 
+type executer interface {
+	execute() (string, error)
+}
+
 func main() {
 	proj := flag.String("p", "", "Project directory")
 	flag.Parse()
@@ -22,7 +26,7 @@ func run(proj string, out io.Writer) error {
 		return fmt.Errorf("project directory is required: %w", ErrValidation)
 	}
 
-	pipeline := make([]step, 2)
+	pipeline := make([]executer, 3)
 	pipeline[0] = newStep(
 		"go build",
 		"go",
@@ -31,6 +35,7 @@ func run(proj string, out io.Writer) error {
 		[]string{"build", ".", "errors"},
 	)
 	pipeline[1] = newStep("go test", "go", "Go test: SUCCESS", proj, []string{"test", "-v"})
+	pipeline[2] = newExceptionStep("go fmt", "gofmt", "gofmt: SUCCESS", proj, []string{"-l", "."})
 
 	for _, step := range pipeline {
 		msg, err := step.execute()

--- a/goci/main_test.go
+++ b/goci/main_test.go
@@ -16,7 +16,7 @@ func TestRun(t *testing.T) {
 		{
 			name:   "success",
 			proj:   "./testdata/tool/",
-			out:    "Go build: SUCCESS\nGo test: SUCCESS\n",
+			out:    "Go build: SUCCESS\nGo test: SUCCESS\ngofmt: SUCCESS\n",
 			expErr: nil,
 		},
 		{
@@ -24,6 +24,12 @@ func TestRun(t *testing.T) {
 			proj:   "./testdata/toolErr/",
 			out:    "",
 			expErr: &StepErr{step: "go build"},
+		},
+		{
+			name:   "failFormat",
+			proj:   "./testdata/toolFmtErr/",
+			out:    "",
+			expErr: &StepErr{step: "go fmt"},
 		},
 	}
 

--- a/goci/main_test.go
+++ b/goci/main_test.go
@@ -16,7 +16,7 @@ func TestRun(t *testing.T) {
 		{
 			name:   "success",
 			proj:   "./testdata/tool/",
-			out:    "Go build: SUCCESS\n",
+			out:    "Go build: SUCCESS\nGo test: SUCCESS\n",
 			expErr: nil,
 		},
 		{

--- a/goci/step.go
+++ b/goci/step.go
@@ -1,0 +1,36 @@
+package main
+
+import "os/exec"
+
+type step struct {
+	name    string
+	exe     string
+	args    []string
+	message string
+	proj    string
+}
+
+func newStep(name, exe, message, proj string, args []string) step {
+	return step{
+		name:    name,
+		exe:     exe,
+		args:    args,
+		message: message,
+		proj:    proj,
+	}
+}
+
+func (s *step) execute() (string, error) {
+	cmd := exec.Command(s.exe, s.args...)
+	cmd.Dir = s.proj
+
+	if err := cmd.Run(); err != nil {
+		return "", &StepErr{
+			step:  s.name,
+			msg:   "failed to execute",
+			cause: err,
+		}
+	}
+
+	return s.message, nil
+}

--- a/goci/step.go
+++ b/goci/step.go
@@ -20,7 +20,7 @@ func newStep(name, exe, message, proj string, args []string) step {
 	}
 }
 
-func (s *step) execute() (string, error) {
+func (s step) execute() (string, error) {
 	cmd := exec.Command(s.exe, s.args...)
 	cmd.Dir = s.proj
 

--- a/goci/testdata/tool/add_test.go
+++ b/goci/testdata/tool/add_test.go
@@ -1,0 +1,15 @@
+package add
+
+import "testing"
+
+func TestAdd(t *testing.T) {
+	a := 2
+	b := 3
+
+	expected := 5
+	result := add(a, b)
+
+	if expected != result {
+		t.Errorf("Expected %d, got %d", expected, result)
+	}
+}

--- a/goci/testdata/toolErr/add_test.go
+++ b/goci/testdata/toolErr/add_test.go
@@ -1,0 +1,15 @@
+package add
+
+import "testing"
+
+func TestAdd(t *testing.T) {
+	a := 2
+	b := 3
+
+	expected := 5
+	result := add(a, b)
+
+	if expected != result {
+		t.Errorf("Expected %d, got %d", expected, result)
+	}
+}

--- a/goci/testdata/toolFmtErr/add.go
+++ b/goci/testdata/toolFmtErr/add.go
@@ -1,0 +1,6 @@
+package add
+
+//The function below is written in an invalid format to trigger gofmt pipeline
+func add(a, b int) int {
+return a + b
+}


### PR DESCRIPTION
New structs called step and exceptionStep are added to create steps from a centralized place.

step is used for a basic operation, if the command returns an error than the step simply fails and propagates the error to goci.

exceptionStep is used for operations which do not return error but prints the errors to `stdout`. `gofmt` can given as an example.

For exceptionStep's, if there is an error on stdout then the step simply fails and propagates the error to goci.

Tests are updated to contain `exceptionStep`.
