### PR TITLE
Add goci git push pipeline step

### DIFF
--- a/goci/main.go
+++ b/goci/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 )
 
 type executer interface {
@@ -26,7 +27,7 @@ func run(proj string, out io.Writer) error {
 		return fmt.Errorf("project directory is required: %w", ErrValidation)
 	}
 
-	pipeline := make([]executer, 3)
+	pipeline := make([]executer, 4)
 	pipeline[0] = newStep(
 		"go build",
 		"go",
@@ -36,6 +37,14 @@ func run(proj string, out io.Writer) error {
 	)
 	pipeline[1] = newStep("go test", "go", "Go test: SUCCESS", proj, []string{"test", "-v"})
 	pipeline[2] = newExceptionStep("go fmt", "gofmt", "gofmt: SUCCESS", proj, []string{"-l", "."})
+	pipeline[3] = newTimeoutStep(
+		"git push",
+		"git",
+		"git push: SUCCESS",
+		proj,
+		[]string{"push", "origin", "master"},
+		10*time.Second,
+	)
 
 	for _, step := range pipeline {
 		msg, err := step.execute()

--- a/goci/main_test.go
+++ b/goci/main_test.go
@@ -3,38 +3,56 @@ package main
 import (
 	"bytes"
 	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 )
 
 func TestRun(t *testing.T) {
+	_, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git is not installed, the test is skipped")
+	}
+
 	testCases := []struct {
-		name   string
-		proj   string
-		out    string
-		expErr error
+		name     string
+		proj     string
+		out      string
+		expErr   error
+		setupGit bool
 	}{
 		{
-			name:   "success",
-			proj:   "./testdata/tool/",
-			out:    "Go build: SUCCESS\nGo test: SUCCESS\ngofmt: SUCCESS\n",
-			expErr: nil,
+			name:     "success",
+			proj:     "./testdata/tool/",
+			out:      "Go build: SUCCESS\nGo test: SUCCESS\ngofmt: SUCCESS\ngit push: SUCCESS\n",
+			expErr:   nil,
+			setupGit: true,
 		},
 		{
-			name:   "fail",
-			proj:   "./testdata/toolErr/",
-			out:    "",
-			expErr: &StepErr{step: "go build"},
+			name:     "fail",
+			proj:     "./testdata/toolErr/",
+			out:      "",
+			expErr:   &StepErr{step: "go build"},
+			setupGit: false,
 		},
 		{
-			name:   "failFormat",
-			proj:   "./testdata/toolFmtErr/",
-			out:    "",
-			expErr: &StepErr{step: "go fmt"},
+			name:     "failFormat",
+			proj:     "./testdata/toolFmtErr/",
+			out:      "",
+			expErr:   &StepErr{step: "go fmt"},
+			setupGit: false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.setupGit {
+				cleanup := setupGit(t, tc.proj)
+				defer cleanup()
+			}
+
 			var out bytes.Buffer
 			err := run(tc.proj, &out)
 
@@ -59,5 +77,62 @@ func TestRun(t *testing.T) {
 				t.Errorf("Excepted output: %q. Got %q instead", tc.out, out.String())
 			}
 		})
+	}
+}
+
+// Helper function to create a mock Git environment to test the git push pipeline step
+func setupGit(t *testing.T, proj string) func() {
+	t.Helper()
+
+	gitExec, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tempDir, err := os.MkdirTemp("", "gocitest")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	absProjPath, err := filepath.Abs(proj)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	remoteGitUri := fmt.Sprintf("file://%s", tempDir)
+	gitCmdList := []struct {
+		args []string
+		dir  string
+		env  []string
+	}{
+		{[]string{"init", "--bare"}, tempDir, nil},
+		{[]string{"init"}, absProjPath, nil},
+		{[]string{"remote", "add", "testOrigin", remoteGitUri}, absProjPath, nil},
+		{[]string{"add", "."}, absProjPath, nil},
+		{[]string{"commit", "-m", "test"}, absProjPath, []string{
+			"GIT_COMMITTER_NAME=test",
+			"GIT_COMMITTER_EMAIL=test@example.com",
+			"GIT_AUTHOR_NAME=test",
+			"GIT_AUTHOR_EMAIL=test@example.com",
+		}},
+	}
+
+	for _, g := range gitCmdList {
+		gitCmd := exec.Command(gitExec, g.args...)
+		gitCmd.Dir = g.dir
+
+		if g.env != nil {
+			gitCmd.Env = append(os.Environ(), g.env...)
+		}
+
+		if err := gitCmd.Run(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Return the cleanup function to use after tests.
+	return func() {
+		os.RemoveAll(tempDir)
+		os.RemoveAll(filepath.Join(absProjPath, ".git"))
 	}
 }

--- a/goci/timeoutStep.go
+++ b/goci/timeoutStep.go
@@ -6,6 +6,7 @@ import (
 	"time"
 )
 
+var command = exec.CommandContext
 
 type timeoutStep struct {
 	step
@@ -32,7 +33,7 @@ func (s timeoutStep) execute() (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, s.exe, s.args...)
+	cmd := command(ctx, s.exe, s.args...)
 	cmd.Dir = s.proj
 
 	if err := cmd.Run(); err != nil {

--- a/goci/timeoutStep.go
+++ b/goci/timeoutStep.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"os/exec"
+	"time"
+)
+
+
+type timeoutStep struct {
+	step
+	timeout time.Duration
+}
+
+func newTimeoutStep(
+	name, exe, message, proj string,
+	args []string,
+	timeout time.Duration,
+) timeoutStep {
+	s := timeoutStep{}
+	s.step = newStep(name, exe, message, proj, args)
+	s.timeout = timeout
+	if s.timeout == 0 {
+		s.timeout = 30 * time.Second
+	}
+
+	return s
+}
+
+func (s timeoutStep) execute() (string, error) {
+	// Create a context to apply timeout in case goci hangs
+	ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, s.exe, s.args...)
+	cmd.Dir = s.proj
+
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", &StepErr{
+				step:  s.name,
+				msg:   "timeout, command failed",
+				cause: context.DeadlineExceeded,
+			}
+		}
+
+		return "", &StepErr{
+			step:  s.name,
+			msg:   "failed to execute",
+			cause: err,
+		}
+	}
+
+	return s.message, nil
+}


### PR DESCRIPTION
A new step called `timeoutStep` is used to execute given commands with a context.

The tests are updated by integrating `git` into a temp directory.

`exec.CommandContext` is moved outside from execute() to a package level variable.

3 new functions are added to main_test.go to mock the cmd used inside `execute()` methods.

- `mockCmdContext` - the main mock which makes goci run TestHelperProcess while running tests.
- `mockCmdTimeout` - the mock method used to simulate a timeout scenario, to test timeoutStep.
- `TestHelperProcess` - this test is used by mocks to skip using real `git` binary and simulate a timeout scenario, which are set up by environment variables.