### PR TITLE
Allow goci to process SIGINT and SIGTERM signals

### DIFF
--- a/goci/errors.go
+++ b/goci/errors.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 )
 
-var ErrValidation = errors.New("validation failed")
+var (
+	ErrValidation = errors.New("validation failed")
+	ErrSignal     = errors.New("received signal")
+)
 
 // Define a custom error to centralize the errors in each step of the CI pipeline
 type StepErr struct {


### PR DESCRIPTION
A new error type is added to define signal errors since these errors are different than regular pipeline errors.

Tests are added for `SIGINT, SIGTERM` signals.
Also another test case is added to see how an ignored signal (eg. `SIGQUIT`) is handled by `goci`.