### PR TITLE
Add host subcommand to pscan

### DIFF
--- a/pscan/cmd/actions_test.go
+++ b/pscan/cmd/actions_test.go
@@ -1,0 +1,171 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/acikgozb/cli-playground/pscan/scan"
+)
+
+// Since host actions depend on a host file to work on
+// We create a helper method to generate a pre-filled dummy host file for us.
+func setup(t *testing.T, hosts []string, initList bool) (string, func()) {
+	temp, err := os.CreateTemp("", "pScan")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We directly close the file since actions just need the file name.
+	temp.Close()
+
+	if initList {
+		hl := &scan.HostsList{}
+
+		for _, host := range hosts {
+			hl.Add(host)
+		}
+
+		if err := hl.Save(temp.Name()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Return the temp file name and cleanup func.
+	return temp.Name(), func() {
+		os.Remove(temp.Name())
+	}
+}
+
+func TestHostActions(t *testing.T) {
+	// Define hosts for action test.
+	hosts := []string{
+		"host1",
+		"host2",
+		"host3",
+	}
+
+	testCases := []struct {
+		name           string
+		args           []string
+		expectedOutput string
+		initList       bool
+		actionFunction func(io.Writer, string, []string) error
+	}{
+		{
+			name:           "AddAction",
+			args:           hosts,
+			expectedOutput: "Added host: host1\nAdded host: host2\nAdded host: host3\n",
+			initList:       false,
+			actionFunction: addAction,
+		},
+		{
+			name:           "ListAction",
+			args:           hosts,
+			expectedOutput: "host1\nhost2\nhost3\n",
+			initList:       true,
+			actionFunction: listAction,
+		},
+		{
+			name:           "DeleteAction",
+			args:           []string{"host1", "host2"},
+			expectedOutput: "Removed the host: host1\nRemoved the host: host2\n",
+			initList:       true,
+			actionFunction: deleteAction,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup action test.
+			tempFileName, cleanup := setup(t, hosts, tc.initList)
+			defer cleanup()
+
+			// Define output to capture
+			var out bytes.Buffer
+
+			// Execute action and capture the output
+			if err := tc.actionFunction(&out, tempFileName, tc.args); err != nil {
+				t.Fatalf("expected no error but got %q\n", err)
+			}
+
+			// Verify the output.
+			if out.String() != tc.expectedOutput {
+				t.Errorf("expected %q as a result but got %q\n", tc.expectedOutput, out.String())
+			}
+		})
+	}
+}
+
+// Integration test
+// The goal is to execute all commands in sequence, simulating what a user would do.
+// Flow: Add 3 hosts, list them and delete one host from the list.
+func TestIntegration(t *testing.T) {
+	// Define the hosts for the test.
+	hosts := []string{
+		"host1",
+		"host2",
+		"host3",
+	}
+
+	// Setup the integration test.
+	// We do not want to initialize the list, CLI should be able to do it by itself.
+	tempFileName, cleanup := setup(t, hosts, false)
+	defer cleanup()
+
+	hostToDelete := "host2"
+	hostsAfterDeletion := []string{
+		"host1",
+		"host3",
+	}
+
+	// Capture the output
+	var out bytes.Buffer
+
+	// Define the expected output by combining all outputs we expect from the test.
+	expectedOutput := ""
+
+	// Output after inserting hosts.
+	for _, host := range hosts {
+		expectedOutput += fmt.Sprintf("Added host: %s\n", host)
+	}
+
+	// Output after listing hosts.
+	expectedOutput += strings.Join(hosts, "\n")
+	expectedOutput += fmt.Sprintln()
+
+	// Output after deleting a host.
+	expectedOutput += fmt.Sprintf("Removed the host: %s\n", hostToDelete)
+	expectedOutput += strings.Join(hostsAfterDeletion, "\n")
+	expectedOutput += fmt.Sprintln()
+
+	// Execute all operations in defined sequence add > list > delete > list.
+
+	// Add hosts to the list.
+	if err := addAction(&out, tempFileName, hosts); err != nil {
+		t.Fatalf("expected no error from addAction but got %q instead", err)
+	}
+
+	// List hosts.
+	if err := listAction(&out, tempFileName, nil); err != nil {
+		t.Fatalf("expected no error from listAction but got %q instead", err)
+	}
+
+	// Delete a host from the list.
+	if err := deleteAction(&out, tempFileName, []string{hostToDelete}); err != nil {
+		t.Fatalf("expected no error from deleteAction but got %q instead", err)
+	}
+
+	// List remaining hosts.
+	if err := listAction(&out, tempFileName, nil); err != nil {
+		t.Fatalf("expected no error from listAction after deletion but got %q instead", err)
+	}
+
+	// Test the output
+	if out.String() != expectedOutput {
+		t.Errorf("expected output to be %q, but got %q instead", expectedOutput, out.String())
+	}
+}

--- a/pscan/cmd/add.go
+++ b/pscan/cmd/add.go
@@ -1,0 +1,68 @@
+/*
+Copyright © 2024 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/acikgozb/cli-playground/pscan/scan"
+	"github.com/spf13/cobra"
+)
+
+// addCmd represents the add command
+var addCmd = &cobra.Command{
+	Use:     "add <host1> ... <hostn>", // let consumer know that he/she can provide any number of hosts.
+	Aliases: []string{"a"},
+	Short:   "Add new host(s) to the list",
+	Args: cobra.MinimumNArgs(
+		1,
+	), // a small validation which Cobra can provide, in this case we want at least one host to be added with this command.
+	SilenceUsage: true, // prevent showing command usage when an error occurs to not cause confusion. The user can still see the usage with -h
+	RunE: func(cmd *cobra.Command, args []string) error {
+		hostsFile, err := cmd.Flags().GetString("hosts-file")
+		if err != nil {
+			return err
+		}
+
+		return addAction(os.Stdout, hostsFile, args)
+	},
+}
+
+func init() {
+	hostsCmd.AddCommand(addCmd)
+}
+
+// addAction runs when users use add command to add a host to the host list.
+// PS: The current design is not suitable for concurrent usage, beware of it.
+func addAction(out io.Writer, hostsFile string, args []string) error {
+	hl := &scan.HostsList{}
+
+	if err := hl.Load(hostsFile); err != nil {
+		return err
+	}
+
+	for _, host := range args {
+		if err := hl.Add(host); err != nil {
+			return err
+		}
+
+		fmt.Fprintln(out, "Added host:", host)
+	}
+
+	return hl.Save(hostsFile)
+}

--- a/pscan/cmd/delete.go
+++ b/pscan/cmd/delete.go
@@ -1,0 +1,70 @@
+/*
+Copyright © 2024 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/acikgozb/cli-playground/pscan/scan"
+	"github.com/spf13/cobra"
+)
+
+// deleteCmd represents the delete command
+var deleteCmd = &cobra.Command{
+	Use:          "delete <host1> ... <hostn>",
+	Aliases:      []string{"d"},
+	Short:        "Delete a host from hosts list",
+	SilenceUsage: true,
+	Args:         cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		hostsFile, err := cmd.Flags().GetString("hosts-file")
+		if err != nil {
+			return err
+		}
+
+		return deleteAction(os.Stdout, hostsFile, args)
+	},
+}
+
+func init() {
+	hostsCmd.AddCommand(deleteCmd)
+}
+
+// deleteAction runs when users use delete command to remove a host to the host list.
+// PS: The current design is not suitable for concurrent usage, beware of it.
+func deleteAction(out io.Writer, hostsFile string, args []string) error {
+	hl := &scan.HostsList{}
+
+	if err := hl.Load(hostsFile); err != nil {
+		return err
+	}
+
+	for _, host := range args {
+		if err := hl.Remove(host); err != nil {
+			return err
+		}
+
+		fmt.Fprintln(out, "Removed the host:", host)
+	}
+
+	if err := hl.Save(hostsFile); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pscan/cmd/hosts.go
+++ b/pscan/cmd/hosts.go
@@ -16,8 +16,6 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -30,9 +28,6 @@ var hostsCmd = &cobra.Command{
     Delete hosts with the delete command
     List hosts with the list command.
     `,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("hosts called")
-	},
 }
 
 func init() {

--- a/pscan/cmd/hosts.go
+++ b/pscan/cmd/hosts.go
@@ -1,0 +1,50 @@
+/*
+Copyright © 2024 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// hostsCmd represents the hosts command
+var hostsCmd = &cobra.Command{
+	Use:   "hosts",
+	Short: "Manage the hosts list",
+	Long: `Manages the hosts lists for pScan
+    Add hosts with the add command
+    Delete hosts with the delete command
+    List hosts with the list command.
+    `,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("hosts called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(hostsCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// hostsCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// hostsCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/pscan/cmd/list.go
+++ b/pscan/cmd/list.go
@@ -1,0 +1,73 @@
+/*
+Copyright © 2024 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/acikgozb/cli-playground/pscan/scan"
+	"github.com/spf13/cobra"
+)
+
+// listCmd represents the list command
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List hosts in hosts list",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Cobra automatically makes all CLI flags available to the current command
+		// via cmd.Flags()
+		hostsFile, err := cmd.Flags().GetString("hosts-file")
+		if err != nil {
+			return err
+		}
+
+		return listAction(os.Stdout, hostsFile, args)
+	},
+	Aliases: []string{"l"},
+}
+
+func init() {
+	hostsCmd.AddCommand(listCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// listCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// listCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+// listAction runs when user calls pscan host list with args
+func listAction(out io.Writer, hostsFile string, args []string) error {
+	hl := &scan.HostsList{}
+
+	if err := hl.Load(hostsFile); err != nil {
+		return err
+	}
+
+	for _, h := range hl.Hosts {
+		if _, err := fmt.Fprintln(out, h); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pscan/cmd/root.go
+++ b/pscan/cmd/root.go
@@ -54,9 +54,9 @@ func init() {
 	rootCmd.PersistentFlags().
 		StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cli-playground.yaml)")
 
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	// Since all commands for host subcommand requires a host file, add that flag as a global option
+	// for host subcommand.
+	rootCmd.PersistentFlags().StringP("hosts-file", "f", "pScan.hosts", "pScan hosts file")
 
 	versionTemplate := `{{printf "%s: %s - version %s\n" .Name .Short .Version}}`
 	rootCmd.SetVersionTemplate(versionTemplate)

--- a/pscan/scan/hostsList.go
+++ b/pscan/scan/hostsList.go
@@ -1,0 +1,82 @@
+// Package scan provides types and functions to perform TCP port
+// scans on a list of hosts.
+package scan
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+)
+
+var (
+	ErrExists    = errors.New("host already in the list")
+	ErrNotExists = errors.New("host not in the list")
+)
+
+// HostList represents a list of hosts to run port scan
+type HostsList struct {
+	Hosts []string
+}
+
+func (hl *HostsList) search(host string) (bool, int) {
+	sort.Strings(hl.Hosts)
+
+	i := sort.SearchStrings(hl.Hosts, host)
+	if i < len(hl.Hosts) && hl.Hosts[i] == host {
+		return true, i
+	}
+
+	return false, -1
+}
+
+func (hl *HostsList) Add(host string) error {
+	if found, _ := hl.search(host); found {
+		return fmt.Errorf("%w:%s", ErrExists, host)
+	}
+
+	hl.Hosts = append(hl.Hosts, host)
+	return nil
+}
+
+func (hl *HostsList) Remove(host string) error {
+	found, i := hl.search(host)
+	if !found {
+		return fmt.Errorf("%w:%s", ErrNotExists, host)
+	}
+
+	hl.Hosts = append(hl.Hosts[:i], hl.Hosts[i+1:]...)
+	return nil
+}
+
+func (hl *HostsList) Load(hostsFile string) error {
+	f, err := os.Open(hostsFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+
+		return err
+	}
+
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+
+	for scanner.Scan() {
+		hl.Hosts = append(hl.Hosts, scanner.Text())
+	}
+
+	return nil
+}
+
+func (hl *HostsList) Save(hostsFile string) error {
+	output := ""
+
+	for _, host := range hl.Hosts {
+		output += fmt.Sprintln(host)
+	}
+
+	return os.WriteFile(hostsFile, []byte(output), 0644)
+}

--- a/pscan/scan/hostsList_test.go
+++ b/pscan/scan/hostsList_test.go
@@ -1,0 +1,170 @@
+package scan_test
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/acikgozb/cli-playground/pscan/scan"
+)
+
+func TestAdd(t *testing.T) {
+	testCases := []struct {
+		name           string
+		host           string
+		expectedLength int
+		expectedError  error
+	}{
+		{"AddNew", "host2", 2, nil},
+		{"AddExisting", "host1", 1, scan.ErrExists},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hl := &scan.HostsList{}
+
+			// Given
+			if err := hl.Add("host1"); err != nil {
+				t.Fatal(err)
+			}
+
+			// When
+			err := hl.Add(tc.host)
+
+			// Then
+			if tc.expectedError != nil {
+				if err == nil {
+					t.Fatalf("expected error, got nil instead.\n")
+				}
+
+				if !errors.Is(err, tc.expectedError) {
+					t.Errorf("expected error %q, got %q instead", tc.expectedError, err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("expected no error but got %q instead\n", err)
+			}
+
+			if len(hl.Hosts) != tc.expectedLength {
+				t.Errorf(
+					"expected list length %d, got %d instead",
+					tc.expectedLength,
+					len(hl.Hosts),
+				)
+			}
+
+			if hl.Hosts[1] != tc.host {
+				t.Errorf(
+					"expected host name %q as index 1, but got %q instead",
+					tc.host,
+					hl.Hosts[1],
+				)
+			}
+		})
+	}
+}
+
+func TestRemove(t *testing.T) {
+	testCases := []struct {
+		name           string
+		host           string
+		expectedLength int
+		expectedError  error
+	}{
+		{"RemoveExisting", "host1", 1, nil},
+		{"RemoveNotFound", "host3", 1, scan.ErrNotExists},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Given
+			hl := &scan.HostsList{}
+
+			for _, dummyHost := range []string{"host1", "host2"} {
+				if err := hl.Add(dummyHost); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// When
+			err := hl.Remove(tc.host)
+
+			// Then
+			if tc.expectedError != nil {
+				if err == nil {
+					t.Errorf("expected error but got nil instead\n")
+				}
+
+				if !errors.Is(err, tc.expectedError) {
+					t.Errorf("expected error %q but got %q instead\n", tc.expectedError, err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("expected no error but got %q instead\n", err)
+			}
+
+			if len(hl.Hosts) != tc.expectedLength {
+				t.Errorf(
+					"expected list length as %d but got %d instead\n",
+					tc.expectedLength,
+					len(hl.Hosts),
+				)
+			}
+		})
+	}
+}
+
+func TestSaveLoad(t *testing.T) {
+	// Given
+	hl1 := &scan.HostsList{}
+	hl2 := &scan.HostsList{}
+
+	hostName := "host1"
+	if err := hl1.Add(hostName); err != nil {
+		t.Fatalf("expected no error while initializing lists in TestSaveLoad but got %q", err)
+	}
+
+	tempFile, err := os.CreateTemp("", "")
+	if err != nil {
+		t.Fatalf("expected no error while creating a temp file for TestSaveLoad but got %q", err)
+	}
+
+	defer os.Remove(tempFile.Name())
+
+	// When
+	if err := hl1.Save(tempFile.Name()); err != nil {
+		// Then
+		t.Fatalf("expected no error while saving hl1 to tempFile but got %q instead", err)
+	}
+
+	// When
+	if err := hl2.Load(tempFile.Name()); err != nil {
+		// Then
+		t.Fatalf("expected no error while loading hl2 with tempFile but got %q instead", err)
+	}
+
+	// Then
+	if hl1.Hosts[0] != hl2.Hosts[0] {
+		t.Errorf(
+			"expected two lists to have the same hosts but got %q in hl1, %q in hl2",
+			hl1.Hosts[0],
+			hl2.Hosts[0],
+		)
+	}
+}
+
+func TestLoadNotExist(t *testing.T) {
+	hl := &scan.HostsList{}
+	fileName := "file-which-does-not-exist"
+
+	err := hl.Load(fileName)
+	if err != nil {
+		t.Errorf("expected load to not return an error if file does not exist, but got %q", err)
+	}
+}


### PR DESCRIPTION
A new subcommand named "host" is added to pscan via `Cobra`.
A new package is written to separate cli logic from `Cobra`.
The business logic for host lists are added under `scan` package, along with their tests.

The host business logic which was written under `scan` package is connected with `Cobra` via the methods below:

- `addAction`
- `removeAction`
- `deleteAction`

`Cobra` parses the flags and passes them to the functions above to do operations on hosts.

Unit tests are added for `add, remove and delete` actions along with an integration test which simulates user behaviour.