### PR TITLE
Add scan subcommand to pscan

### DIFF
--- a/pscan/cmd/scan.go
+++ b/pscan/cmd/scan.go
@@ -1,0 +1,88 @@
+/*
+Copyright © 2024 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/acikgozb/cli-playground/pscan/scan"
+	"github.com/spf13/cobra"
+)
+
+// scanCmd represents the scan command
+var scanCmd = &cobra.Command{
+	Use:   "scan",
+	Short: "Run a port scan on the hosts",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		hostsFile, err := cmd.Flags().GetString("hosts-file")
+		if err != nil {
+			return err
+		}
+
+		ports, err := cmd.Flags().GetIntSlice("ports")
+		if err != nil {
+			return err
+		}
+
+		return scanAction(os.Stdout, hostsFile, ports)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(scanCmd)
+
+	scanCmd.Flags().IntSliceP("ports", "p", []int{22, 80, 443}, "ports to scan")
+}
+
+// scanAction ties Cobra with our scan package.
+func scanAction(out io.Writer, hostsFile string, ports []int) error {
+	hl := &scan.HostsList{}
+
+	if err := hl.Load(hostsFile); err != nil {
+		return err
+	}
+
+	results := scan.Run(hl, ports)
+	return printResults(out, results)
+}
+
+func printResults(out io.Writer, results []scan.Results) error {
+	message := ""
+
+	// The string concatnation here is not optimized for large results,
+	// it is just used for covering this basic CLI application.
+	for _, r := range results {
+		message += fmt.Sprintf("%s:", r.Host)
+
+		if r.NotFound {
+			message += " Host not found\n\n"
+			continue
+		}
+
+		message += fmt.Sprintln()
+
+		for _, p := range r.PortStates {
+			message += fmt.Sprintf("\t%d: %s\n", p.Port, p.Open)
+		}
+
+		message += fmt.Sprintln()
+	}
+
+	_, err := fmt.Fprint(out, message)
+	return err
+}

--- a/pscan/scan/scanHosts.go
+++ b/pscan/scan/scanHosts.go
@@ -1,0 +1,75 @@
+package scan
+
+import (
+	"fmt"
+	"net"
+	"time"
+)
+
+// PortState represents the state of a single TCP port.
+type PortState struct {
+	Port int
+	Open state
+}
+
+type Results struct {
+	Host       string
+	NotFound   bool
+	PortStates []PortState
+}
+
+// By creating custom types, we can associate methods to it.
+type state bool
+
+// String converts the boolean value of state to a human readable string
+func (s state) String() string {
+	if s {
+		return "open"
+	}
+
+	return "closed"
+}
+
+// scanPort performs a port scan on a single TCP port
+func scanPort(host string, port int) PortState {
+	p := PortState{
+		Port: port,
+	}
+
+	address := net.JoinHostPort(host, fmt.Sprintf("%d", port))
+	scanConn, err := net.DialTimeout("tcp", address, 1*time.Second)
+	if err != nil {
+		// Assume that error means the port is not open.
+		return p
+	}
+
+	scanConn.Close()
+	p.Open = true
+	return p
+}
+
+// Run performs a port scan on the hosts list.
+func Run(hl *HostsList, ports []int) []Results {
+	res := make([]Results, 0, len(hl.Hosts))
+
+	for _, h := range hl.Hosts {
+		r := Results{
+			Host: h,
+		}
+
+		// Resolve the host name into a volid IP address.
+		if _, err := net.LookupHost(h); err != nil {
+			r.NotFound = true
+			res = append(res, r)
+			continue
+		}
+
+		for _, p := range ports {
+			r.PortStates = append(r.PortStates, scanPort(h, p))
+		}
+
+		res = append(res, r)
+	}
+
+	return res
+}

--- a/pscan/scan/scanHosts_test.go
+++ b/pscan/scan/scanHosts_test.go
@@ -1,0 +1,123 @@
+package scan_test
+
+import (
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/acikgozb/cli-playground/pscan/scan"
+)
+
+func TestStateString(t *testing.T) {
+	ps := scan.PortState{}
+
+	if ps.Open.String() != "closed" {
+		t.Errorf("expected %q as port state but got %q", "closed", ps.Open.String())
+	}
+
+	ps.Open = true
+
+	if ps.Open.String() != "open" {
+		t.Errorf("expected %q as port state but got %q", "open", ps.Open.String())
+	}
+}
+
+func TestRunHostFound(t *testing.T) {
+	testCases := []struct {
+		name          string
+		expectedState string
+	}{
+		{"OpenPort", "open"},
+		{"ClosedPort", "closed"},
+	}
+
+	host := "localhost"
+	hl := scan.HostsList{}
+
+	hl.Add(host)
+
+	ports := []int{}
+	// Init ports, 1 open, 1 closed
+	for _, tc := range testCases {
+		ln, err := net.Listen("tcp", net.JoinHostPort(host, "0"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		defer ln.Close()
+
+		_, portStr, err := net.SplitHostPort(ln.Addr().String())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		port, err := strconv.Atoi(portStr)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ports = append(ports, port)
+
+		if tc.name == "ClosedPort" {
+			// Instead of deferring the close call, we immediately close it for 2nd test case.
+			ln.Close()
+		}
+	}
+
+	// When
+	res := scan.Run(&hl, ports)
+
+	// Then
+	if len(res) != 1 {
+		t.Fatalf("expected 1 result, got %q instead\n", len(res))
+	}
+
+	if res[0].Host != host {
+		t.Fatalf("expected host %q, got %q instead\n", host, res[0].Host)
+	}
+
+	if res[0].NotFound {
+		t.Fatalf("expected host %q to be found\n", host)
+	}
+
+	if len(res[0].PortStates) != 2 {
+		t.Fatalf("expected 2 port states, got %d instead\n", len(res[0].PortStates))
+	}
+
+	for i, tc := range testCases {
+		if res[0].PortStates[i].Port != ports[i] {
+			t.Errorf("expected port %d, got %d instead\n", ports[i], res[0].PortStates[i].Port)
+		}
+
+		if res[0].PortStates[i].Open.String() != tc.expectedState {
+			t.Errorf("expected port %d to be %s\n", ports[i], tc.expectedState)
+		}
+	}
+}
+
+func TestRunHostNotFound(t *testing.T) {
+	// This host should fail to be found unless you have it on your DNS:
+	host := "389.389.389.389"
+
+	hl := scan.HostsList{}
+	hl.Add(host)
+
+	res := scan.Run(&hl, []int{})
+
+	// Verify the output - one Results, not found, empty PortState
+	if len(res) != 1 {
+		t.Fatalf("expected 1 results, got %d instead", len(res))
+	}
+
+	if res[0].Host != host {
+		t.Errorf("expected host to be %s, got %s instead\n", host, res[0].Host)
+	}
+
+	if !res[0].NotFound {
+		t.Errorf("expected host %q not to be found", host)
+	}
+
+	if len(res[0].PortStates) != 0 {
+		t.Errorf("expected no portStates, but got %d portStates", len(res[0].PortStates))
+	}
+}


### PR DESCRIPTION
The scan functionality is implemented in `scan` package along with tests.

A new subcommand called `scan` is added to the CLI via `Cobra`, along with the adapter function `scanAction`. 
Tests are added for `scanAction`.
Integration test is updated to contain `scanAction` as well.